### PR TITLE
Fix bug where incorrect property is accessed in getCoinPrice

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ const userFavoritesStorage = StableBTreeMap(Principal, UserFavorites, 1);
  * - getFavoriteNfts: retrieves the list of favorite nfts for the current user.
  */
 export default Canister({
-  getCoinPrice: update([text], Result(text, text), async (nftId) => {
+    getCoinPrice: update([text], Result(text, text), async (nftId) => {
     const nft = nftId.toLowerCase();
 
     const response = await ic.call(managementCanister.http_request, {
@@ -72,12 +72,12 @@ export default Canister({
 
     var body = JSON.parse(new TextDecoder().decode(response.body));
 
-    if (!body[nft]) {
+    if (!body["floor_price"]) {
       return Err("Nft not found");
     }
 
-    const price = body[nft].usd;
-    return Ok(`The price of ${nft} is $${price}`);
+    const price = body["floor_price"]["usd"];
+    return Ok(`The price of ${nft} is $ ${price}`);
   }),
 
   saveFavoriteNft: update([Nft], Result(text, text), (nft) => {


### PR DESCRIPTION
Fix a bug where the incorrect property of the body variable was used in one of the if statements of the getCoinPrice function which would result in the error `'Err("Nft not found")'` always being returned. Furthermore, I've also updated the price variable to access the correct properties for the USD price. 